### PR TITLE
Fix out-of-bounds reads, DEP crash, and stack overflow in hook library

### DIFF
--- a/hook.c
+++ b/hook.c
@@ -93,7 +93,7 @@ DWORD hook(LPVOID lpThreadParameter) {
 		fseek(file, 0, SEEK_SET);
 
 		buffer = (char*)malloc(count);
-		fread(buffer, 1, count, file);
+		count = fread(buffer, 1, count, file);
 		fclose(file);
 	}
 
@@ -106,7 +106,7 @@ DWORD hook(LPVOID lpThreadParameter) {
 		cur->data = &buffer[i];
 
 		size_t index = i;
-		for (; i < count && buffer[index] != '\n' && buffer[index] != '\0'; index++);
+		for (; index < count && buffer[index] != '\n' && buffer[index] != '\0'; index++);
 
 		cur->len = index - i;
 		i = index + 1;

--- a/hook.c
+++ b/hook.c
@@ -47,7 +47,6 @@ int createUTF8FromWideStringWin32(const WCHAR* source, char* output, size_t max)
 		return 0;
 	}
 
-	output[size] = 0;
 	return size;
 }
 

--- a/hook.c
+++ b/hook.c
@@ -286,7 +286,7 @@ void LoadRealBink() {
         exit(1);
     }
 
-	char err_str[256];
+	static char err_str[256];
 
     /* Load Function Pointers */
     #define LOAD_FUNC(name, dll, fail) real_##name = (name##_t)GetProcAddress(hRealBink, #dll); \
@@ -295,7 +295,7 @@ void LoadRealBink() {
 								if (fail) { \
 									MessageBoxA(NULL, (char*)err_str, (char*)err_str, MB_ICONERROR); \
 									exit(0); \
-								} else CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)err_str, err_str, 0, NULL); \
+								} else CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)debug, err_str, 0, NULL); \
                             }
 
     LOAD_FUNC(BinkOpen, _BinkOpen@8, 1)


### PR DESCRIPTION
Fixes stability issues in `hook.c`:
1. Corrects the loop condition in title list parsing to avoid reading past the allocated heap buffer.
2. Fixes thread creation in `LOAD_FUNC` by passing the `debug` callback function instead of attempting to execute string memory on the stack.
3. Eliminates a 1-byte stack overflow during window title UTF-8 conversions.